### PR TITLE
RFC: A couple of fixes & updates to implement join/quit/kick to matrix, and kick/ban/unban from matrix

### DIFF
--- a/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/MCListener.java
+++ b/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/MCListener.java
@@ -5,6 +5,9 @@ import dev.dhdf.polo.webclient.WebClient;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerKickEvent;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 
 
@@ -18,6 +21,28 @@ public class MCListener implements Listener {
 
     public MCListener(WebClient client) {
         this.client = client;
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent ev) {
+        Player player = ev.getPlayer();
+
+        this.client.postJoin(new PoloPlayer(player.getName(), player.getUniqueId()));
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent ev) {
+        Player player = ev.getPlayer();
+
+        this.client.postQuit(new PoloPlayer(player.getName(), player.getUniqueId()));
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onPlayerKick(PlayerKickEvent ev) {
+        Player player = ev.getPlayer();
+        String kickReason = ev.getReason();
+
+        this.client.postKick(new PoloPlayer(player.getName(), player.getUniqueId()), kickReason);
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/MCListener.java
+++ b/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/MCListener.java
@@ -20,7 +20,7 @@ public class MCListener implements Listener {
         this.client = client;
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onPlayerChat(AsyncPlayerChatEvent ev) {
         String body = ev.getMessage();
         Player player = ev.getPlayer();

--- a/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/Main.java
+++ b/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/Main.java
@@ -4,12 +4,16 @@ import dev.dhdf.polo.PoloPlugin;
 import dev.dhdf.polo.util.Sync;
 import dev.dhdf.polo.webclient.Config;
 import dev.dhdf.polo.webclient.WebClient;
+import org.bukkit.entity.Player;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.BanList;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.logging.Logger;
+import java.util.UUID;
 
 
 /**
@@ -35,7 +39,9 @@ public class Main extends JavaPlugin implements PoloPlugin {
                 pluginConfig.getString("address"),
                 pluginConfig.getInt("port"),
                 pluginConfig.getString("token"),
-                pluginConfig.getBoolean("relay-minecraft-membership")
+                pluginConfig.getBoolean("relay-minecraft-membership"),
+                pluginConfig.getBoolean("relay-matrix-kicks"),
+                pluginConfig.getBoolean("relay-matrix-bans")
         );
 
         // Start up the web client
@@ -93,6 +99,70 @@ public class Main extends JavaPlugin implements PoloPlugin {
     @Override
     public void broadcastMessage(String message) {
         this.getServer().broadcastMessage(message);
+    }
+
+    @Override
+    public void kickPlayer(UUID uuid, String reason, String source) {
+        Player player = this.getServer().getPlayer(uuid);
+        if (player == null) {
+            Logger logger = getLogger();
+            logger.info("No player to kick with UUID " + uuid.toString());
+            return;
+        }
+        getServer().getScheduler().runTask(this, new Runnable() {
+            public void run() {
+                player.kickPlayer(reason);
+                getServer().broadcast(source + " kicked " + player.getName() + " for " + reason, "matrix.kick.notify");
+            }
+        });
+    }
+
+    @Override
+    public void banPlayer(UUID uuid, String reason, String source) {
+        // Ban the player using UUID
+        String uuidString = uuid.toString();
+        if (getServer().getBanList(BanList.Type.NAME).addBan(uuidString, reason, null, source) == null) {
+            Logger logger = getLogger();
+            logger.warning("No player to ban with UUID " + uuidString);
+            return;
+        }
+
+        // Notify others of the ban
+        OfflinePlayer offlinePlayer = getServer().getOfflinePlayer(uuid);
+        getServer().broadcast(source + " banned " + offlinePlayer.getName() + " for " + reason, "matrix.ban.notify");
+
+        // If online, kick now
+        Player player = offlinePlayer.getPlayer();
+        if (player != null) {
+            getServer().getScheduler().runTask(this, new Runnable() {
+                public void run() {
+                    player.kickPlayer("You have been banned: " + reason);
+                }
+            });
+        }
+    }
+
+    @Override
+    public void unbanPlayer(UUID uuid, String source) {
+        String uuidString = uuid.toString();
+
+        OfflinePlayer offlinePlayer = getServer().getOfflinePlayer(uuid);
+        String name = offlinePlayer.getName();
+        if (name == null)
+            name = uuidString;
+
+        // Skip unban if there is no ban already present (which would imply we have a name)
+        if (!offlinePlayer.isBanned()) {
+            Logger logger = getLogger();
+            logger.info("Player '" + name + "' isn't banned, so can't be unbanned");
+            return;
+        }
+
+        // Unban the player using UUID
+        getServer().getBanList(BanList.Type.NAME).pardon(uuidString);
+
+        // Notify others of the unban
+        getServer().broadcast(source + " unbanned " + name, "matrix.unban.notify");
     }
 
     @Override

--- a/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/Main.java
+++ b/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/Main.java
@@ -34,7 +34,8 @@ public class Main extends JavaPlugin implements PoloPlugin {
         Config config = new Config(
                 pluginConfig.getString("address"),
                 pluginConfig.getInt("port"),
-                pluginConfig.getString("token")
+                pluginConfig.getString("token"),
+                pluginConfig.getBoolean("relay-minecraft-membership")
         );
 
         // Start up the web client

--- a/polo-bukkit/src/main/resources/config.yml
+++ b/polo-bukkit/src/main/resources/config.yml
@@ -1,3 +1,14 @@
 address: "127.0.0.1"
 port: 3051
 token: ""
+
+# Whether to relay Minecraft player joins, quits & kicks to Matrix.
+# If this is set to true, fake Matrix users will:
+#  - join the Matrix room when the player connects to the Minecraft server.
+#  - leave the Matrix room when the player quits from the Minecraft server.
+#  - get kicked from the Matrix room by the _mc_bot user when the player is
+#    kicked from the Minecraft server (make sure that the _mc_bot has
+#    sufficient privileges to kick users).
+# If this is set to false, fake Matrix users will join the room only to relay
+# chat messages from players, and won't leave by themselves.
+relay-minecraft-membership: true

--- a/polo-bukkit/src/main/resources/config.yml
+++ b/polo-bukkit/src/main/resources/config.yml
@@ -12,3 +12,14 @@ token: ""
 # If this is set to false, fake Matrix users will join the room only to relay
 # chat messages from players, and won't leave by themselves.
 relay-minecraft-membership: true
+
+# Whether to relay Matrix kicks to Minecraft.
+# If this is set to true, the plugin will respond to fake Matrix users being
+# kicked by kicking the corresponding player from the minecraft server.
+relay-matrix-kicks: true
+
+# Whether to relay Matrix bans & unbans to Minecraft.
+# If this is set to true, the plugin will respond to fake Matrix users being
+# banned or unbanned by banning or unbanning the corresponding player from the
+# Minecraft server.
+relay-matrix-bans: true

--- a/polo-bukkit/src/main/resources/plugin.yml
+++ b/polo-bukkit/src/main/resources/plugin.yml
@@ -3,3 +3,13 @@ version: '1.0.0'
 author: 'Dylan Hackworth'
 main: 'dev.dhdf.polo.bukkit.Main'
 api-version: '1.15'
+permissions:
+  matrix.kick.notify:
+    description: Notifications of kicks from Matrix.
+    default: op
+  matrix.ban.notify:
+    description: Notifications of bans from Matrix.
+    default: op
+  matrix.unban.notify:
+    description: Notifications of unbans from Matrix.
+    default: op

--- a/polo-common/src/main/java/dev/dhdf/polo/PoloPlugin.java
+++ b/polo-common/src/main/java/dev/dhdf/polo/PoloPlugin.java
@@ -1,11 +1,36 @@
 package dev.dhdf.polo;
 
+import java.util.UUID;
+
 public interface PoloPlugin {
     /**
      * Broadcast a Matrix message to the server.
      * @param message The message to broadcast
      */
     public void broadcastMessage(String message);
+
+    /**
+     * Kick a player from the server.
+     * @param uuid Player UUID
+     * @param reason The reason for the kick
+     * @param source Where the kick came from
+     */
+    public void kickPlayer(UUID uuid, String reason, String source);
+
+    /**
+     * Ban a player from the server.
+     * @param uuid Player UUID
+     * @param reason The reason for the ban
+     * @param source Where the ban came from
+     */
+    public void banPlayer(UUID uuid, String reason, String source);
+
+    /**
+     * Unban a player from the server.
+     * @param uuid Player UUID
+     * @param source Where the unban came from
+     */
+    public void unbanPlayer(UUID uuid, String source);
 
     /**
      * Execute a task asynchronously using the plugin's scheduler.

--- a/polo-common/src/main/java/dev/dhdf/polo/types/MCEvent.java
+++ b/polo-common/src/main/java/dev/dhdf/polo/types/MCEvent.java
@@ -1,0 +1,11 @@
+package dev.dhdf.polo.types;
+
+import org.json.JSONObject;
+
+public abstract class MCEvent {
+    public abstract JSONObject toJSON();
+
+    public String toString() {
+        return toJSON().toString();
+    }
+}

--- a/polo-common/src/main/java/dev/dhdf/polo/types/MCJoin.java
+++ b/polo-common/src/main/java/dev/dhdf/polo/types/MCJoin.java
@@ -1,0 +1,17 @@
+package dev.dhdf.polo.types;
+
+import org.json.JSONObject;
+
+public class MCJoin extends MCEvent {
+    public final PoloPlayer player;
+
+    public MCJoin(PoloPlayer player) {
+        this.player = player;
+    }
+
+    @Override
+    public JSONObject toJSON() {
+        return new JSONObject()
+            .put("player", player.toJSON());
+    }
+}

--- a/polo-common/src/main/java/dev/dhdf/polo/types/MCKick.java
+++ b/polo-common/src/main/java/dev/dhdf/polo/types/MCKick.java
@@ -1,0 +1,20 @@
+package dev.dhdf.polo.types;
+
+import org.json.JSONObject;
+
+public class MCKick extends MCEvent {
+    public final PoloPlayer player;
+    public final String reason;
+
+    public MCKick(PoloPlayer player, String reason) {
+        this.player = player;
+        this.reason = reason;
+    }
+
+    @Override
+    public JSONObject toJSON() {
+        return new JSONObject()
+            .put("player", player.toJSON())
+            .put("reason", this.reason);
+    }
+}

--- a/polo-common/src/main/java/dev/dhdf/polo/types/MCMessage.java
+++ b/polo-common/src/main/java/dev/dhdf/polo/types/MCMessage.java
@@ -1,8 +1,8 @@
 package dev.dhdf.polo.types;
 
-import org.json.JSONStringer;
+import org.json.JSONObject;
 
-public class MCMessage {
+public class MCMessage extends MCEvent {
     public final PoloPlayer player;
     public final String message;
 
@@ -11,19 +11,10 @@ public class MCMessage {
         this.message = message;
     }
 
-    public String toString() {
-        return new JSONStringer()
-                .object()
-                .key("player")
-                .object()
-                .key("name")
-                .value(this.player.name)
-                .key("uuid")
-                .value(this.player.uuid)
-                .endObject()
-                .key("message")
-                .value(this.message)
-                .endObject()
-                .toString();
+    @Override
+    public JSONObject toJSON() {
+        return new JSONObject()
+            .put("player", player.toJSON())
+            .put("message", this.message);
     }
 }

--- a/polo-common/src/main/java/dev/dhdf/polo/types/MCQuit.java
+++ b/polo-common/src/main/java/dev/dhdf/polo/types/MCQuit.java
@@ -1,0 +1,17 @@
+package dev.dhdf.polo.types;
+
+import org.json.JSONObject;
+
+public class MCQuit extends MCEvent {
+    public final PoloPlayer player;
+
+    public MCQuit(PoloPlayer player) {
+        this.player = player;
+    }
+
+    @Override
+    public JSONObject toJSON() {
+        return new JSONObject()
+            .put("player", player.toJSON());
+    }
+}

--- a/polo-common/src/main/java/dev/dhdf/polo/types/PoloPlayer.java
+++ b/polo-common/src/main/java/dev/dhdf/polo/types/PoloPlayer.java
@@ -1,5 +1,7 @@
 package dev.dhdf.polo.types;
 
+import org.json.JSONObject;
+
 import java.util.UUID;
 
 public class PoloPlayer {
@@ -9,5 +11,11 @@ public class PoloPlayer {
     public PoloPlayer(String name, UUID uuid) {
         this.name = name;
         this.uuid = uuid.toString().replace("-", "");
+    }
+
+    public JSONObject toJSON() {
+        return new JSONObject()
+                .put("name", this.name)
+                .put("uuid", this.uuid);
     }
 }

--- a/polo-common/src/main/java/dev/dhdf/polo/util/Sync.java
+++ b/polo-common/src/main/java/dev/dhdf/polo/util/Sync.java
@@ -2,6 +2,9 @@ package dev.dhdf.polo.util;
 
 import dev.dhdf.polo.webclient.WebClient;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.TimerTask;
 
 
@@ -11,13 +14,29 @@ import java.util.TimerTask;
  */
 public class Sync implements Runnable {
     private final WebClient client;
+    private final Logger logger = LoggerFactory.getLogger(Sync.class);
+
+    private boolean supportsEvents;
 
     public Sync(WebClient client) {
         this.client = client;
+        this.supportsEvents = true;
     }
 
     @Override
     public void run() {
-        this.client.getChat();
+        // Default to the events endpoint unless we know it isn't supported
+        if (!supportsEvents || !this.client.getEvents()) {
+            // Fall back to the legacy plain chat endpoint
+            if (!this.client.getChat()) {
+                // Even the legacy endpoint failed, next time try the events
+                // endpoint too
+                supportsEvents = true;
+            } else if (supportsEvents) {
+                // It worked! just use this in future
+                logger.warn("Falling back to legacy chat endpoint, please update matrix-appservice-minecraft");
+                supportsEvents = false;
+            }
+        }
     }
 }

--- a/polo-common/src/main/java/dev/dhdf/polo/webclient/Config.java
+++ b/polo-common/src/main/java/dev/dhdf/polo/webclient/Config.java
@@ -9,12 +9,18 @@ public class Config {
     public final int port;
     public final String token;
     public final boolean relayMinecraftMembership;
+    public final boolean relayMatrixKicks;
+    public final boolean relayMatrixBans;
 
     public Config(String address, int port, String token,
-                  boolean relayMinecraftMembership) {
+                  boolean relayMinecraftMembership,
+                  boolean relayMatrixKicks,
+                  boolean relayMatrixBans) {
         this.address = address;
         this.port = port;
         this.token = token;
         this.relayMinecraftMembership = relayMinecraftMembership;
+        this.relayMatrixKicks = relayMatrixKicks;
+        this.relayMatrixBans = relayMatrixBans;
     }
 }

--- a/polo-common/src/main/java/dev/dhdf/polo/webclient/Config.java
+++ b/polo-common/src/main/java/dev/dhdf/polo/webclient/Config.java
@@ -8,10 +8,13 @@ public class Config {
     public final String address;
     public final int port;
     public final String token;
+    public final boolean relayMinecraftMembership;
 
-    public Config(String address, int port, String token) {
+    public Config(String address, int port, String token,
+                  boolean relayMinecraftMembership) {
         this.address = address;
         this.port = port;
         this.token = token;
+        this.relayMinecraftMembership = relayMinecraftMembership;
     }
 }

--- a/polo-common/src/main/java/dev/dhdf/polo/webclient/WebClient.java
+++ b/polo-common/src/main/java/dev/dhdf/polo/webclient/WebClient.java
@@ -153,7 +153,7 @@ public class WebClient {
                     return null;
                 }
             } else {
-                logger.error("An invalid endpoint was called for.");
+                logger.error("An invalid endpoint {} was called for.", endpoint);
                 return null;
             }
         } catch (java.net.ConnectException e) {

--- a/polo-common/src/main/java/dev/dhdf/polo/webclient/WebClient.java
+++ b/polo-common/src/main/java/dev/dhdf/polo/webclient/WebClient.java
@@ -24,17 +24,12 @@ import java.net.URL;
  * events that occurred (which is only chat messages at the moment)
  */
 public class WebClient {
-    private final String address;
-    private final int port;
-    private final String token;
-
     private final Logger logger = LoggerFactory.getLogger(WebClient.class);
+    private final Config config;
     private final PoloPlugin plugin;
 
     public WebClient(PoloPlugin plugin, Config config) {
-        this.address = config.address;
-        this.port = config.port;
-        this.token = config.token;
+        this.config = config;
         this.plugin = plugin;
     }
 
@@ -110,12 +105,12 @@ public class WebClient {
     public JSONObject doRequest(String method, String endpoint, String body, Boolean expectJSON) {
         try {
             URL url = new URL(
-                    "http://" + address + ":" + port + endpoint
+                    "http://" + config.address + ":" + config.port + endpoint
             );
 
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod(method);
-            connection.setRequestProperty("Authorization", "Bearer " + this.token);
+            connection.setRequestProperty("Authorization", "Bearer " + config.token);
             connection.setRequestProperty("Content-Type", "application/json");
             connection.setRequestProperty("User-Agent", "Marco Spigot Plugin");
 

--- a/polo-common/src/main/java/dev/dhdf/polo/webclient/WebClient.java
+++ b/polo-common/src/main/java/dev/dhdf/polo/webclient/WebClient.java
@@ -2,6 +2,9 @@ package dev.dhdf.polo.webclient;
 
 import dev.dhdf.polo.PoloPlugin;
 import dev.dhdf.polo.types.MCMessage;
+import dev.dhdf.polo.types.MCJoin;
+import dev.dhdf.polo.types.MCQuit;
+import dev.dhdf.polo.types.MCKick;
 import dev.dhdf.polo.types.PoloPlayer;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -31,6 +34,80 @@ public class WebClient {
     public WebClient(PoloPlugin plugin, Config config) {
         this.config = config;
         this.plugin = plugin;
+    }
+
+    /**
+     * Send player join event to Marco
+     *
+     * @param player Player object representing a Minecraft player who has
+     *                  joined the server, it must be parsed before sent to
+     *                  Marco
+     */
+    public void postJoin(PoloPlayer player) {
+        if (!config.relayMinecraftMembership)
+            return;
+
+        MCJoin join = new MCJoin(player);
+        String body = join.toString();
+
+        // Run communication outside the server thread
+        plugin.executeAsync(() ->
+                this.doRequest(
+                        "POST",
+                        "/player/join",
+                        body,
+                        false
+                )
+        );
+    }
+
+    /**
+     * Send player quit event to Marco
+     *
+     * @param player Player object representing a Minecraft player who has quit
+     *                  the server, it must be parsed before sent to Marco
+     */
+    public void postQuit(PoloPlayer player) {
+        if (!config.relayMinecraftMembership)
+            return;
+
+        MCQuit quit = new MCQuit(player);
+        String body = quit.toString();
+
+        // Run communication outside the server thread
+        plugin.executeAsync(() ->
+                this.doRequest(
+                        "POST",
+                        "/player/quit",
+                        body,
+                        false
+                )
+        );
+    }
+
+    /**
+     * Send player kick event to Marco
+     *
+     * @param player Player object representing a Minecraft player who has been
+     *                  kicked, it must be parsed before sent to Marco
+     * @param reason The reason for the player being kicked
+     */
+    public void postKick(PoloPlayer player, String reason) {
+        if (!config.relayMinecraftMembership)
+            return;
+
+        MCKick kick = new MCKick(player, reason);
+        String body = kick.toString();
+
+        // Run communication outside the server thread
+        plugin.executeAsync(() ->
+                this.doRequest(
+                        "POST",
+                        "/player/kick",
+                        body,
+                        false
+                )
+        );
     }
 
     /**

--- a/polo-sponge/src/main/java/dev/dhdf/polo/sponge/Main.java
+++ b/polo-sponge/src/main/java/dev/dhdf/polo/sponge/Main.java
@@ -134,7 +134,7 @@ public class Main implements PoloPlugin {
         }
 
         public dev.dhdf.polo.webclient.Config getConfig() {
-            return new dev.dhdf.polo.webclient.Config(address, port, token);
+            return new dev.dhdf.polo.webclient.Config(address, port, token, false);
         }
     }
 }

--- a/polo-sponge/src/main/java/dev/dhdf/polo/sponge/Main.java
+++ b/polo-sponge/src/main/java/dev/dhdf/polo/sponge/Main.java
@@ -27,6 +27,7 @@ import org.spongepowered.api.text.channel.MessageChannel;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+import java.util.UUID;
 
 
 @Plugin(id = "polo",
@@ -105,6 +106,18 @@ public class Main implements PoloPlugin {
     }
 
     @Override
+    public void kickPlayer(UUID uuid, String reason, String source) {
+    }
+
+    @Override
+    public void banPlayer(UUID uuid, String reason, String source) {
+    }
+
+    @Override
+    public void unbanPlayer(UUID uuid, String source) {
+    }
+
+    @Override
     public void executeAsync(Runnable task) {
         Task.builder()
                 .async()
@@ -134,7 +147,7 @@ public class Main implements PoloPlugin {
         }
 
         public dev.dhdf.polo.webclient.Config getConfig() {
-            return new dev.dhdf.polo.webclient.Config(address, port, token, false);
+            return new dev.dhdf.polo.webclient.Config(address, port, token, false, false, false);
         }
     }
 }


### PR DESCRIPTION
This corresponds to https://github.com/dhghf/matrix-appservice-minecraft/pull/24

A couple of fixes first, to prevent relay of cancelled bukkit user messages and improve log output when an invalid endpoint is called. These are ready for pull.

Then for Bukkit only, we use the join/quit/kick API to notify the appservice of membership changes.

Then we start using the new structured events API to get new messages & events (safely falling back to the old API).

* [x] As per the appservice PR, The IDs probably need changing

Finally we implement kicks, bans and unbans for Bukkit, doing the same to the actual Minecraft user.

* [ ] Translation of kick/ban/unban notification broadcasts? I haven't looked into how to do that properly, and it doesn't matter to me personally.