### PR TITLE
Skins & Nicks

### DIFF
--- a/polo-bukkit/build.gradle
+++ b/polo-bukkit/build.gradle
@@ -11,6 +11,9 @@ repositories {
             includeGroup 'org.bukkit'
         }
     }
+    maven {
+        url = 'https://ci.ender.zone/plugin/repository/everything/'
+    }
 }
 
 dependencies {
@@ -18,6 +21,9 @@ dependencies {
 
     runtimeOnly "org.slf4j:slf4j-jdk14:${slf4jVersion}"
     compileOnly 'org.bukkit:bukkit:1.15.2-R0.1-SNAPSHOT'
+    compileOnly('net.ess3:EssentialsX:2.16.1') {
+        transitive = false
+    }
 }
 
 assemble.dependsOn shadowJar

--- a/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/BukkitHelper.java
+++ b/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/BukkitHelper.java
@@ -1,0 +1,132 @@
+/* Derived from:
+ * https://github.com/webbukkit/dynmap.git
+ * commit bc57d443345a81ba983f594421908ac33fd07940
+ * bukkit-helper/src/main/java/org/dynmap/bukkit/helper/BukkitVersionHelperGeneric.java
+ * License: Apache License 2.0
+ */
+package dev.dhdf.polo.bukkit;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.logging.Logger;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import com.google.common.collect.ForwardingMultimap;
+import com.google.common.collect.Iterables;
+
+/**
+ * Helper for isolation of bukkit version specific issues
+ */
+public class BukkitHelper {
+    private String obc_package; // Package used for org.bukkit.craftbukkit
+    private boolean failed;
+    protected static final Object[] nullargs = new Object[0];
+
+    // CraftPlayer
+    private Class<?> obc_craftplayer;
+    private Method obcplayer_getprofile;
+    // GameProfile
+    private Class<?> cma_gameprofile;
+    private Method cmaprofile_getproperties;
+    // Property
+    private Class<?> cma_property;
+    private Method cmaproperty_getvalue;
+
+    protected BukkitHelper() {
+        failed = false;
+        /* Look up base classname for bukkit server - tells us OBC package */
+        obc_package = Bukkit.getServer().getClass().getPackage().getName();
+
+        // CraftPlayer
+        obc_craftplayer = getOBCClass("org.bukkit.craftbukkit.entity.CraftPlayer");
+        obcplayer_getprofile = getMethod(obc_craftplayer, new String[] { "getProfile" }, new Class[0]);
+        // GameProfile
+        cma_gameprofile = getOBCClass("com.mojang.authlib.GameProfile");
+        cmaprofile_getproperties = getMethod(cma_gameprofile, new String[] { "getProperties" }, new Class[0]);
+        // Property
+        cma_property = getOBCClass("com.mojang.authlib.properties.Property");
+        cmaproperty_getvalue = getMethod(cma_property, new String[] { "getValue" }, new Class[0]);
+
+        if (failed)
+            throw new IllegalArgumentException("Error initializing bukkit helper - bukkit version incompatible!");
+    }
+
+    protected Class<?> getOBCClass(String classname) {
+        return getClassByName(classname, "org.bukkit.craftbukkit", obc_package, false);
+    }
+
+    protected Class<?> getClassByName(String classname, String base, String mapping, boolean nofail) {
+        String n = classname;
+        int idx = classname.indexOf(base);
+        if (idx >= 0) {
+            n = classname.substring(0, idx) + mapping + classname.substring(idx + base.length());
+        }
+        try {
+            return Class.forName(n);
+        } catch (ClassNotFoundException cnfx) {
+            try {
+                return Class.forName(classname);
+            } catch (ClassNotFoundException cnfx2) {
+                if (!nofail) {
+                    Logger logger = Bukkit.getServer().getLogger();
+                    logger.warning("Cannot find " + classname);
+                    failed = true;
+                }
+                return null;
+            }
+        }
+    }
+
+    /**
+     * Get method
+     */
+    protected Method getMethod(Class<?> cls, String[] ids, Class<?>[] args) {
+        if (cls == null)
+            return null;
+        for(String id : ids) {
+            try {
+                return cls.getMethod(id, args);
+            } catch (SecurityException e) {
+            } catch (NoSuchMethodException e) {
+            }
+        }
+        Logger logger = Bukkit.getServer().getLogger();
+        logger.warning("Unable to find method " + ids[0] + " for " + cls.getName());
+        failed = true;
+        return null;
+    }
+    protected Object callMethod(Object obj, Method meth, Object[] args, Object def) {
+        if ((obj == null) || (meth == null))
+            return def;
+        try {
+            return meth.invoke(obj, args);
+        } catch (IllegalArgumentException iax) {
+        } catch (IllegalAccessException e) {
+        } catch (InvocationTargetException e) {
+        }
+        return def;
+    }
+
+    /**
+     * Get texture (which includes skin URL) for player
+     * @param player
+     */
+    public String getTexture(Player player) {
+        Object profile = callMethod(player, obcplayer_getprofile, nullargs, null);
+        if (profile != null) {
+            Object propmap = callMethod(profile, cmaprofile_getproperties, nullargs, null);
+            if ((propmap != null) && (propmap instanceof ForwardingMultimap)) {
+                ForwardingMultimap<String, Object> fmm = (ForwardingMultimap<String, Object>) propmap;
+                Collection<Object> txt = fmm.get("textures");
+                Object textureProperty = Iterables.getFirst(fmm.get("textures"), null);
+                if (textureProperty != null)
+                    return (String) callMethod(textureProperty, cmaproperty_getvalue, nullargs, null);
+            }
+        }
+
+        return null;
+    }
+}

--- a/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/Ess3Listener.java
+++ b/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/Ess3Listener.java
@@ -1,0 +1,35 @@
+package dev.dhdf.polo.bukkit;
+
+import dev.dhdf.polo.types.PoloPlayer;
+import dev.dhdf.polo.webclient.WebClient;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.Plugin;
+import net.ess3.api.events.NickChangeEvent;
+
+
+/**
+ * This class listens to all Essentials specific events happening on Minecraft.
+ */
+public class Ess3Listener extends PoloListener implements Listener {
+    public Ess3Listener(Plugin plugin, WebClient client) {
+        super(plugin, client);
+    }
+
+    // EssentialsX events
+    @EventHandler(ignoreCancelled = true)
+    public void onNickChange(NickChangeEvent ev) {
+        // To avoid complexities with interpreting the new nickname before it
+        // has been applied, just wait a tick before posting the update.
+        plugin.getServer().getScheduler().runTask(plugin, () -> {
+            Player player = ev.getController().getBase();
+            // Avoid race with disconnect
+            if (!player.isOnline())
+                return;
+
+            PoloPlayer poloPlayer = newPoloPlayer(player);
+            this.client.postJoin(poloPlayer);
+        });
+    }
+}

--- a/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/MCListener.java
+++ b/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/MCListener.java
@@ -12,44 +12,44 @@ import org.bukkit.event.player.AsyncPlayerChatEvent;
 
 
 /**
- * This class listens to all the events happening on Minecraft. Currently
- * it only listens to player chat events.
+ * This class listens to all the standard bukkit events happening on Minecraft.
  */
-public class MCListener implements Listener {
-
-    private final WebClient client;
-
+public class MCListener extends PoloListener implements Listener {
     public MCListener(WebClient client) {
-        this.client = client;
+        super(client);
     }
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent ev) {
         Player player = ev.getPlayer();
+        PoloPlayer poloPlayer = newPoloPlayer(player);
 
-        this.client.postJoin(new PoloPlayer(player.getName(), player.getUniqueId()));
+        this.client.postJoin(poloPlayer);
     }
 
     @EventHandler
     public void onPlayerQuit(PlayerQuitEvent ev) {
         Player player = ev.getPlayer();
+        PoloPlayer poloPlayer = newPoloPlayer(player);
 
-        this.client.postQuit(new PoloPlayer(player.getName(), player.getUniqueId()));
+        this.client.postQuit(poloPlayer);
     }
 
     @EventHandler(ignoreCancelled = true)
     public void onPlayerKick(PlayerKickEvent ev) {
         Player player = ev.getPlayer();
         String kickReason = ev.getReason();
+        PoloPlayer poloPlayer = newPoloPlayer(player);
 
-        this.client.postKick(new PoloPlayer(player.getName(), player.getUniqueId()), kickReason);
+        this.client.postKick(poloPlayer, kickReason);
     }
 
     @EventHandler(ignoreCancelled = true)
     public void onPlayerChat(AsyncPlayerChatEvent ev) {
         String body = ev.getMessage();
         Player player = ev.getPlayer();
+        PoloPlayer poloPlayer = newPoloPlayer(player);
 
-        this.client.postChat(new PoloPlayer(player.getName(), player.getUniqueId()), body);
+        this.client.postChat(poloPlayer, body);
     }
 }

--- a/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/MCListener.java
+++ b/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/MCListener.java
@@ -2,6 +2,7 @@ package dev.dhdf.polo.bukkit;
 
 import dev.dhdf.polo.types.PoloPlayer;
 import dev.dhdf.polo.webclient.WebClient;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;

--- a/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/Main.java
+++ b/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/Main.java
@@ -54,7 +54,7 @@ public class Main extends JavaPlugin implements PoloPlugin {
         Logger.getLogger(WebClient.class.getName()).setParent(getLogger());
 
         // Start up the Minecraft event listener
-        MCListener mcListener = new MCListener(webClient);
+        MCListener mcListener = new MCListener(this, webClient);
 
         getServer().getPluginManager().registerEvents(mcListener, this);
 

--- a/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/Main.java
+++ b/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/Main.java
@@ -9,6 +9,7 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.BanList;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.PluginManager;
 
 import java.util.Timer;
 import java.util.TimerTask;
@@ -54,11 +55,16 @@ public class Main extends JavaPlugin implements PoloPlugin {
         Logger.getLogger(WebClient.class.getName()).setParent(getLogger());
 
         // Start up the Minecraft event listener
-        MCListener mcListener = new MCListener(this, webClient);
-
-        getServer().getPluginManager().registerEvents(mcListener, this);
+        PluginManager manager = getServer().getPluginManager();
+        manager.registerEvents(new MCListener(this, webClient), this);
 
         logger.info("Started webclient and chat listeners");
+
+        // Start up the Essentials event listener if the plugin is enabled
+        if (manager.isPluginEnabled("Essentials")) {
+            manager.registerEvents(new Ess3Listener(this, webClient), this);
+            logger.info("Started Essentials listener");
+        }
 
         // See if the address and port are pointing to Marco
         boolean vibeCheck = webClient.vibeCheck();

--- a/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/PoloListener.java
+++ b/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/PoloListener.java
@@ -1,0 +1,21 @@
+package dev.dhdf.polo.bukkit;
+
+import dev.dhdf.polo.types.PoloPlayer;
+import dev.dhdf.polo.webclient.WebClient;
+import org.bukkit.entity.Player;
+
+
+/**
+ * This is a base class for listeners of events happening on Minecraft.
+ */
+public class PoloListener {
+    protected final WebClient client;
+
+    public PoloListener(WebClient client) {
+        this.client = client;
+    }
+
+    protected PoloPlayer newPoloPlayer(Player player) {
+        return new PoloPlayer(player.getName(), player.getUniqueId());
+    }
+}

--- a/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/PoloListener.java
+++ b/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/PoloListener.java
@@ -10,12 +10,14 @@ import org.bukkit.entity.Player;
  */
 public class PoloListener {
     protected final WebClient client;
+    private final BukkitHelper helper;
 
     public PoloListener(WebClient client) {
         this.client = client;
+        this.helper = new BukkitHelper();
     }
 
     protected PoloPlayer newPoloPlayer(Player player) {
-        return new PoloPlayer(player.getName(), player.getUniqueId());
+        return new PoloPlayer(player.getName(), player.getUniqueId(), helper.getTexture(player));
     }
 }

--- a/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/PoloListener.java
+++ b/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/PoloListener.java
@@ -21,6 +21,9 @@ public class PoloListener {
     }
 
     protected PoloPlayer newPoloPlayer(Player player) {
-        return new PoloPlayer(player.getName(), player.getUniqueId(), helper.getTexture(player));
+        // Strip out Minecraft formatting codes from the display name
+        String displayName = player.getDisplayName().replaceAll("\u00a7.", "");
+        return new PoloPlayer(player.getName(), player.getUniqueId(),
+                              displayName, helper.getTexture(player));
     }
 }

--- a/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/PoloListener.java
+++ b/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/PoloListener.java
@@ -3,16 +3,19 @@ package dev.dhdf.polo.bukkit;
 import dev.dhdf.polo.types.PoloPlayer;
 import dev.dhdf.polo.webclient.WebClient;
 import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
 
 
 /**
  * This is a base class for listeners of events happening on Minecraft.
  */
 public class PoloListener {
+    protected final Plugin plugin;
     protected final WebClient client;
     private final BukkitHelper helper;
 
-    public PoloListener(WebClient client) {
+    public PoloListener(Plugin plugin, WebClient client) {
+        this.plugin = plugin;
         this.client = client;
         this.helper = new BukkitHelper();
     }

--- a/polo-bukkit/src/main/resources/plugin.yml
+++ b/polo-bukkit/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ version: '1.0.0'
 author: 'Dylan Hackworth'
 main: 'dev.dhdf.polo.bukkit.Main'
 api-version: '1.15'
+softdepend: [Essentials]
 permissions:
   matrix.kick.notify:
     description: Notifications of kicks from Matrix.

--- a/polo-common/src/main/java/dev/dhdf/polo/types/PoloPlayer.java
+++ b/polo-common/src/main/java/dev/dhdf/polo/types/PoloPlayer.java
@@ -7,11 +7,13 @@ import java.util.UUID;
 public class PoloPlayer {
     public final String name;
     public final String uuid;
+    public final String displayName;
     public final String texture;
 
-    public PoloPlayer(String name, UUID uuid, String texture) {
+    public PoloPlayer(String name, UUID uuid, String displayName, String texture) {
         this.name = name;
         this.uuid = uuid.toString().replace("-", "");
+        this.displayName = displayName;
         this.texture = texture;
     }
 
@@ -19,6 +21,7 @@ public class PoloPlayer {
         return new JSONObject()
                 .put("name", this.name)
                 .put("uuid", this.uuid)
+                .put("displayName", this.displayName)
                 .put("texture", this.texture);
     }
 }

--- a/polo-common/src/main/java/dev/dhdf/polo/types/PoloPlayer.java
+++ b/polo-common/src/main/java/dev/dhdf/polo/types/PoloPlayer.java
@@ -7,15 +7,18 @@ import java.util.UUID;
 public class PoloPlayer {
     public final String name;
     public final String uuid;
+    public final String texture;
 
-    public PoloPlayer(String name, UUID uuid) {
+    public PoloPlayer(String name, UUID uuid, String texture) {
         this.name = name;
         this.uuid = uuid.toString().replace("-", "");
+        this.texture = texture;
     }
 
     public JSONObject toJSON() {
         return new JSONObject()
                 .put("name", this.name)
-                .put("uuid", this.uuid);
+                .put("uuid", this.uuid)
+                .put("texture", this.texture);
     }
 }

--- a/polo-sponge/src/main/java/dev/dhdf/polo/sponge/Main.java
+++ b/polo-sponge/src/main/java/dev/dhdf/polo/sponge/Main.java
@@ -75,7 +75,7 @@ public class Main implements PoloPlugin {
             return;
         }
 
-        PoloPlayer player = new PoloPlayer(source.getName(), source.getUniqueId(), null);
+        PoloPlayer player = new PoloPlayer(source.getName(), source.getUniqueId(), null, null);
         String message = evt.getFormatter().getBody().toText().toPlain();
         this.client.postChat(player, message);
     }

--- a/polo-sponge/src/main/java/dev/dhdf/polo/sponge/Main.java
+++ b/polo-sponge/src/main/java/dev/dhdf/polo/sponge/Main.java
@@ -75,7 +75,7 @@ public class Main implements PoloPlugin {
             return;
         }
 
-        PoloPlayer player = new PoloPlayer(source.getName(), source.getUniqueId());
+        PoloPlayer player = new PoloPlayer(source.getName(), source.getUniqueId(), null);
         String message = evt.getFormatter().getBody().toText().toPlain();
         this.client.postChat(player, message);
     }


### PR DESCRIPTION
These patches make the Bukkit plugin send the player's skin texture and displayName (e.g. EssentialsX /nick) to the appservice.

- First PoloPlayer creation is abstracted for Bukkit
- Next we pass the player's skin texture with MC events. BukkitHelper is borrowed from dynmap.
- Next join events are delayed a little
- Next we pass displayName with events
- Finally we listen for EssentialsX NickChangeEvents so nick changes are immediately reflected at the matrix end

This PR corresponds with https://github.com/dylhack/matrix-appservice-minecraft/pull/32