### PR TITLE
IntermediateJSON: Fix comparison of strings with !=

### DIFF
--- a/polo-common/src/main/java/dev/dhdf/polo/types/IntermediateJSON.java
+++ b/polo-common/src/main/java/dev/dhdf/polo/types/IntermediateJSON.java
@@ -381,7 +381,7 @@ public class IntermediateJSON {
     private static void linkToComponent(JSONObject obj,
                                         TextComponent.Builder newObj) {
         String href = obj.optString("href", "");
-        if (href != "") {
+        if (!href.isEmpty()) {
             newObj.hoverEvent(HoverEvent.showText(Component.text(href)));
             try {
                 newObj.clickEvent(ClickEvent.openUrl(new URL(href)));


### PR DESCRIPTION
Comparing strings with != is bad practice, even though I imagine it may
be safe in practice in this case, so use isEmpty() instead.

Reported-by: aimiebell